### PR TITLE
fix: prevent samples from leaking OAuth client ID + Secret to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ exact URL that the service will use when performing the OAuth flow:
  * Logs the callback URL to register.
  */
 function logCallbackUrl() {
-  var service = getService();
+  var service = getService_();
   Logger.log(service.getCallbackUrl());
 }
 ```
@@ -69,7 +69,7 @@ object each time you want to use it. The example below shows how to create a
 service for the Twitter API.
 
 ```js
-function getTwitterService() {
+function getTwitterService_() {
   // Create a new service with the given name. The name will be used when
   // persisting the authorized token, so ensure it is unique within the
   // scope of the property store.
@@ -98,7 +98,7 @@ authorization URL.
 
 ```js
 function showSidebar() {
-  var twitterService = getTwitterService();
+  var twitterService = getTwitterService_();
   if (!twitterService.hasAccess()) {
     var authorizationUrl = twitterService.authorize();
     var template = HtmlService.createTemplate(
@@ -122,7 +122,7 @@ to the user.
 
 ```js
 function authCallback(request) {
-  var twitterService = getTwitterService();
+  var twitterService = getTwitterService_();
   var isAuthorized = twitterService.handleCallback(request);
   if (isAuthorized) {
     return HtmlService.createHtmlOutput('Success! You can close this tab.');
@@ -144,7 +144,7 @@ and automatically signs the requests using the OAuth1 token.
 
 ```js
 function makeRequest() {
-  var twitterService = getTwitterService();
+  var twitterService = getTwitterService_();
   var response = twitterService.fetch('https://api.twitter.com/1.1/statuses/user_timeline.json');
   // ...
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ information is not persisted to any data store, so you'll need to create this
 object each time you want to use it. The example below shows how to create a
 service for the Twitter API.
 
+Ensure the method is private (has an underscore at the end of the name) to
+prevent clients from being able to call the method to read your client ID and
+secret.
+
 ```js
 function getTwitterService_() {
   // Create a new service with the given name. The name will be used when

--- a/samples/Etsy.gs
+++ b/samples/Etsy.gs
@@ -12,7 +12,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the Etsy API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://openapi.etsy.com/v2/users/__SELF__/profile';
     var response = service.fetch(url);
@@ -32,14 +32,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   var service = OAuth1.createService('Etsy')
       // Set the endpoint URLs.
       // Pass the desired scopes in the request token URL.
@@ -62,7 +62,7 @@ function getService() {
 
   // Override the callback URL method to use the web app URL instead.
   service.getCallbackUrl = function() {
-    return ScriptApp.getService().getUrl();
+    return ScriptApp.getService_().getUrl();
   };
 
   return service;
@@ -74,7 +74,7 @@ function getService() {
 function doGet(request) {
   // Determine if the request is part of an OAuth callback.
   if (request.parameter.oauth_token) {
-    var service = getService();
+    var service = getService_();
     var authorized = service.handleCallback(request);
     if (authorized) {
       return HtmlService.createHtmlOutput('Success!');

--- a/samples/Goodreads.gs
+++ b/samples/Goodreads.gs
@@ -12,7 +12,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the Goodreads API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://www.goodreads.com/api/auth_user';
     var response = service.fetch(url);
@@ -29,14 +29,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   var service = OAuth1.createService('Goodreads')
       // Set the endpoint URLs.
       .setAccessTokenUrl('https://www.goodreads.com/oauth/access_token')
@@ -59,7 +59,7 @@ function getService() {
   
   // Override the callback URL method to use the web app URL instead.
   service.getCallbackUrl = function() {
-    return ScriptApp.getService().getUrl();
+    return ScriptApp.getService_().getUrl();
   };
   
   return service;
@@ -71,7 +71,7 @@ function getService() {
 function doGet(request) {
   // Determine if the request is part of an OAuth callback.
   if (request.parameter.oauth_token) {
-    var service = getService();
+    var service = getService_();
     var authorized = service.handleCallback(request);
     if (authorized) {
       return HtmlService.createHtmlOutput('Success!');

--- a/samples/Jira.gs
+++ b/samples/Jira.gs
@@ -12,7 +12,7 @@ var PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n
  * Authorizes and makes a request to the Xero API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = SITE + '/rest/api/3/myself';
     var response = service.fetch(url, {
@@ -33,13 +33,13 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  getService().reset();
+  getService_().reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('Jira')
       // Set the endpoint URLs.
       .setRequestTokenUrl(SITE + '/plugins/servlet/oauth/request-token')
@@ -68,7 +68,7 @@ function getService() {
  * Handles the OAuth callback.
  */
 function authCallback(request) {
-  var service = getService();
+  var service = getService_();
   var authorized = service.handleCallback(request);
   if (authorized) {
     return HtmlService.createHtmlOutput('Success!');

--- a/samples/KhanAcademy.gs
+++ b/samples/KhanAcademy.gs
@@ -5,7 +5,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the TripIt API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://api.khanacademy.org/api/v1/user';
     var response = service.fetch(url);
@@ -22,14 +22,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('TripIt')
       // Set the endpoint URLs.
       .setRequestTokenUrl('https://www.khanacademy.org/api/auth2/request_token')
@@ -55,7 +55,7 @@ function getService() {
  * Handles the OAuth2 callback.
  */
 function authCallback(request) {
-  var service = getService();
+  var service = getService_();
   var authorized = service.handleCallback(request);
   if (authorized) {
     return HtmlService.createHtmlOutput('Success!');

--- a/samples/QuickBooks.gs
+++ b/samples/QuickBooks.gs
@@ -6,7 +6,7 @@ var CONSUMER_SECRET = '...';
  * sandbox company.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var companyId = PropertiesService.getUserProperties()
         .getProperty('QuickBooks.companyId');
@@ -30,14 +30,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('QuickBooks')
       // Set the endpoint URLs.
       .setAccessTokenUrl('https://oauth.intuit.com/oauth/v1/get_access_token')
@@ -60,7 +60,7 @@ function getService() {
  * Handles the OAuth callback.
  */
 function authCallback(request) {
-  var service = getService();
+  var service = getService_();
   var authorized = service.handleCallback(request);
   if (authorized) {
     PropertiesService.getUserProperties()

--- a/samples/Semantics3.gs
+++ b/samples/Semantics3.gs
@@ -5,7 +5,7 @@ var API_SECRET = '...';
  * Authorizes and makes a request to the Semantics3 API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   var query = encodeURIComponent(JSON.stringify({
     search: 'iPhone'
   }));
@@ -18,7 +18,7 @@ function run() {
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('Semantics3')
       // Set the consumer key and secret.
       .setConsumerKey(API_KEY)

--- a/samples/Trello.gs
+++ b/samples/Trello.gs
@@ -5,7 +5,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the Trello API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://api.trello.com/1/members/me/boards';
     var response = service.fetch(url);
@@ -22,14 +22,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('Trello')
       // Set the endpoint URLs.
       .setRequestTokenUrl('https://trello.com/1/OAuthGetRequestToken')
@@ -52,7 +52,7 @@ function getService() {
  * Handles the OAuth2 callback.
  */
 function authCallback(request) {
-  var service = getService();
+  var service = getService_();
   var authorized = service.handleCallback(request);
   if (authorized) {
     return HtmlService.createHtmlOutput('Success!');

--- a/samples/TripIt.gs
+++ b/samples/TripIt.gs
@@ -5,7 +5,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the TripIt API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://api.tripit.com/v1/get/profile?format=json';
     var response = service.fetch(url);
@@ -22,14 +22,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('TripIt')
       // Set the endpoint URLs.
       .setRequestTokenUrl('https://api.tripit.com/oauth/request_token')
@@ -55,7 +55,7 @@ function getService() {
  * Handles the OAuth callback.
  */
 function authCallback(request) {
-  var service = getService();
+  var service = getService_();
   var authorized = service.handleCallback(request);
   if (authorized) {
     return HtmlService.createHtmlOutput('Success!');

--- a/samples/Twitter.gs
+++ b/samples/Twitter.gs
@@ -5,7 +5,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the Twitter API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://api.twitter.com/1.1/statuses/update.json';
     var payload = {
@@ -28,14 +28,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('Twitter')
       // Set the endpoint URLs.
       .setAccessTokenUrl('https://api.twitter.com/oauth/access_token')
@@ -62,7 +62,7 @@ function getService() {
  * Handles the OAuth callback.
  */
 function authCallback(request) {
-  var service = getService();
+  var service = getService_();
   var authorized = service.handleCallback(request);
   if (authorized) {
     return HtmlService.createHtmlOutput('Success!');

--- a/samples/XeroPrivate.gs
+++ b/samples/XeroPrivate.gs
@@ -19,7 +19,7 @@ var PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n
  * Authorizes and makes a request to the Xero API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   var url = 'https://api.xero.com/api.xro/2.0/Organisations';
   var response = service.fetch(url, {
     headers: {
@@ -34,13 +34,13 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  getService().reset();
+  getService_().reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('Xero')
       // Set the consumer key and secret.
       .setConsumerKey(CONSUMER_KEY)

--- a/samples/XeroPublic.gs
+++ b/samples/XeroPublic.gs
@@ -21,7 +21,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the Xero API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://api.xero.com/api.xro/2.0/Organisations';
     var response = service.fetch(url, {
@@ -42,14 +42,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   var service = OAuth1.createService('Xero')
       // Set the endpoint URLs.
       .setRequestTokenUrl('https://api.xero.com/oauth/RequestToken')
@@ -69,7 +69,7 @@ function getService() {
 
   // Override the callback URL method to use the web app URL instead.
   service.getCallbackUrl = function() {
-    return ScriptApp.getService().getUrl();
+    return ScriptApp.getService_().getUrl();
   };
 
   // Override the parseToken_ method to record the time granted.
@@ -103,7 +103,7 @@ function getService() {
 function doGet(request) {
   // Determine if the request is part of an OAuth callback.
   if (request.parameter.oauth_token) {
-    var service = getService();
+    var service = getService_();
     var authorized = service.handleCallback(request);
     if (authorized) {
       return HtmlService.createHtmlOutput('Success!');

--- a/samples/Xing.gs
+++ b/samples/Xing.gs
@@ -5,7 +5,7 @@ var CONSUMER_SECRET = '...';
  * Authorizes and makes a request to the Xing API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   if (service.hasAccess()) {
     var url = 'https://api.xing.com/v1/users/me';
     var response = service.fetch(url);
@@ -22,14 +22,14 @@ function run() {
  * Reset the authorization state, so that it can be re-tested.
  */
 function reset() {
-  var service = getService();
+  var service = getService_();
   service.reset();
 }
 
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('Xing')
       // Set the endpoint URLs.
       .setRequestTokenUrl('https://api.xing.com/v1/request_token')
@@ -52,7 +52,7 @@ function getService() {
  * Handles the OAuth2 callback.
  */
 function authCallback(request) {
-  var service = getService();
+  var service = getService_();
   var authorized = service.handleCallback(request);
   if (authorized) {
     return HtmlService.createHtmlOutput('Success!');

--- a/samples/Yelp.gs
+++ b/samples/Yelp.gs
@@ -7,7 +7,7 @@ var TOKEN_SECRET = '...';
  * Authorizes and makes a request to the Yelp API.
  */
 function run() {
-  var service = getService();
+  var service = getService_();
   var url = 'https://api.yelp.com/v2/search?term=food&location=San+Francisco';
   var response = service.fetch(url);
   var result = JSON.parse(response.getContentText());
@@ -17,7 +17,7 @@ function run() {
 /**
  * Configures the service.
  */
-function getService() {
+function getService_() {
   return OAuth1.createService('Yelp')
       // Set the consumer key and secret.
       .setConsumerKey(CONSUMER_KEY)


### PR DESCRIPTION
This mirrors the same PR in the OAuth2 library: https://github.com/googleworkspace/apps-script-oauth2/pull/379

Previously, the getService method was public in most of the samples, letting any user of any sample application execute the method using google.script.run to exfiltrate the OAuth Client ID and Secret from the server.
Now, these methods are made private by appending an _ to their names, preventing this issue.
See also similar issue in the OAuth2 library: https://github.com/googleworkspace/apps-script-oauth2/issues/378

closes #53 