### PR TITLE
chore: Enable release-please workflows & deployment with clasp

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,0 +1,6 @@
+{
+  "scriptId": "1CXDCY5sqT9ph64fFwSzVtXnbjpSfWdRymafDrtIZ7Z_hwysTY7IIhi7s",
+  "rootDir": "src/",
+  "fileExtension": "gs"
+}
+

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.pr }}
+      - uses: actions/setup-node@v1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          node-version: 16
+      - name: Write test credentials
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          echo "${CLASP_CREDENTIALS}" > "${HOME}/.clasprc.json"
+        env:
+          CLASP_CREDENTIALS: ${{secrets.LIBRARIES_OWNER_CLASP_TOKEN}}
+      - name: Depoy scripts
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          npx @google/clasp push
+          npx @google/clasp version

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -1,0 +1,27 @@
+on: [pull_request]
+name: Update dist folder
+jobs:
+  update-dist-src:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate dist
+        run: npm run dist
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+      - name: Push changes
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'Google Workspace Bot'
+          git config --global user.email 'googleworkspace-bot@google.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GOOGLEWORKSPACE_BOT_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "chore: Update dist/ directory"
+          git push

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -2,7 +2,8 @@ on: [pull_request]
 name: Update dist folder
 jobs:
   update-dist-src:
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    if: |
+        ${{ contains(github.event.pull_request.labels.*.name, "autorelease: pending") }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -2,11 +2,13 @@ on: [pull_request]
 name: Update dist folder
 jobs:
   update-dist-src:
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GOOGLEWORKSPACE_BOT_TOKEN }}
       - uses: actions/setup-node@v1
         with:
           node-version: 16
@@ -22,6 +24,5 @@ jobs:
         run: |
           git config --global user.name 'Google Workspace Bot'
           git config --global user.email 'googleworkspace-bot@google.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GOOGLEWORKSPACE_BOT_TOKEN }}@github.com/${{ github.repository }}
           git commit -am "chore: Update dist/ directory"
           git push

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -1,0 +1,11 @@
+{
+  "timeZone": "America/New_York",
+  "dependencies": {
+    "libraries": [{
+      "userSymbol": "Underscore",
+      "libraryId": "1I21uLOwDKdyF3_W_hvh6WXiIKWJWno8yG9lB8lf1VBnZFQ6jAAhyNTRG",
+      "version": "24"
+    }]
+  },
+  "exceptionLogging": "STACKDRIVER"
+}


### PR DESCRIPTION
Creates workflows for deploying script. Several flows here:

* update-dist.yml: Ensures PRs that touch source also update the dist/ folder
* release-please.yml: Uses release-please to manage releases
* deploy.yml: Deploys released code to apps script & bumps the deployment/version.
